### PR TITLE
BUG: Azure storage has a maximum visibility delay

### DIFF
--- a/src/AsyncCaller.Sdk/Nexus.Link.AsyncCaller.Sdk.csproj
+++ b/src/AsyncCaller.Sdk/Nexus.Link.AsyncCaller.Sdk.csproj
@@ -19,7 +19,7 @@
 
   <PropertyGroup>
     <PackageId>Nexus.Link.AsyncCaller.Sdk</PackageId>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>nexus;link;fulcrum;lever</PackageTags>
     <Authors>XLENT Link</Authors>
@@ -29,6 +29,7 @@
     <Copyright>Copyright ©2020 Xlent Link AB</Copyright>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageReleaseNotes>
+      2.1.2 Azure storage queue doesn't accept InitialVisibilityDelay &gt;= 7 days
       2.1.1 Compensate for bug in dotnet core regarding HTTP header "Expires: -1"
       2.1.0 Support for Async Caller Dispatching in Azure functions and for multiple queues
       2.0.23 Bump

--- a/test/AsyncCaller.UnitTests/AyncCallTests.cs
+++ b/test/AsyncCaller.UnitTests/AyncCallTests.cs
@@ -5,6 +5,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Nexus.Link.AsyncCaller.Sdk;
 using Nexus.Link.AsyncCaller.Sdk.Data.Models;
+using Nexus.Link.AsyncCaller.Sdk.Data.Queues;
+using Nexus.Link.AsyncCaller.Sdk.Storage.Queue;
 using Nexus.Link.Libraries.Core.Application;
 
 namespace AsyncCaller.Sdk.UnitTests
@@ -53,6 +55,35 @@ namespace AsyncCaller.Sdk.UnitTests
             await asyncCall.ExecuteAsync();
             Assert.IsNotNull(foundRawRequest);
             Assert.AreEqual(2, foundRawRequest.Priority);
+        }
+
+        [TestMethod]
+        public async Task MaxDelayTimeAccordingToAzureStorageQueue()
+        {
+            // Arrange
+            TimeSpan? actualTimeSpan = null;
+            var queueMock = new Mock<IQueue>();
+            queueMock
+                .Setup(ac => ac.AddMessageAsync(It.IsAny<string>(), It.Is<TimeSpan?>(span => span != null)))
+                .Callback((string s, TimeSpan? ts) => actualTimeSpan = ts)
+                .Returns(Task.CompletedTask);
+            queueMock
+                .Setup(ac => ac.MaybeCreateAndConnect(It.IsAny<string>()));
+
+            var requestQueue = new RequestQueue(queueMock.Object, nameof(AsyncCall));
+            var envelope = new RawRequestEnvelope
+            {
+                Attempts = 1000, // Big number to ensure that we get a long delay
+                RawRequest = new RawRequest{Id = null}
+            };
+
+            // Act
+            await requestQueue.RequeueAsync(envelope, null);
+
+            // Assert
+            Assert.IsNotNull(actualTimeSpan);
+            var expectedTimeSpan = TimeSpan.FromDays(7) - TimeSpan.FromSeconds(1);
+            Assert.AreEqual(expectedTimeSpan, actualTimeSpan);
         }
     }
 }


### PR DESCRIPTION
We got these errors, when our delay time was too long:
The argument 'initialVisibilityDelay' is larger than maximum of '6.23:59:59' Parameter name: initialVisibilityDelay

See also [Meistertask](https://www.meistertask.com/app/task/uKzKSnrB/ac-max-7-day-backoff)

I have added a test case that failed, corrected the code and the test case now succeeds.
